### PR TITLE
Added ability to change font

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Wheel of fortune will run only once by default but if you want to run it more th
 | isOnlyOnce     |     true      |      Yes |
 | upDuration     |      100      |      Yes |
 | downDuration   |     1000      |      Yes |
+| fontFamily     |'proxima-nova' |      Yes |
 
 ## Usage
 
@@ -80,6 +81,7 @@ const App = () => {
       size={290}
       upDuration={100}
       downDuration={1000}
+      fontFamily='Arial'
     />
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ const WheelComponent = ({
   isOnlyOnce = true,
   size = 290,
   upDuration = 100,
-  downDuration = 1000
+  downDuration = 1000,
+  fontFamily = 'proxima-nova'
 }) => {
   let currentSegment = ''
   let isStarted = false
@@ -128,7 +129,7 @@ const WheelComponent = ({
     ctx.translate(centerX, centerY)
     ctx.rotate((lastAngle + angle) / 2)
     ctx.fillStyle = contrastColor || 'white'
-    ctx.font = 'bold 1em proxima-nova'
+    ctx.font = 'bold 1em ' + fontFamily
     ctx.fillText(value.substr(0, 21), size / 2 + 20, 0)
     ctx.restore()
   }
@@ -142,7 +143,7 @@ const WheelComponent = ({
     ctx.strokeStyle = primaryColor || 'black'
     ctx.textBaseline = 'middle'
     ctx.textAlign = 'center'
-    ctx.font = '1em proxima-nova'
+    ctx.font = '1em ' + fontFamily
     for (let i = 1; i <= len; i++) {
       const angle = PI2 * (i / len) + angleCurrent
       drawSegment(i - 1, lastAngle, angle)
@@ -157,7 +158,7 @@ const WheelComponent = ({
     ctx.lineWidth = 10
     ctx.strokeStyle = contrastColor || 'white'
     ctx.fill()
-    ctx.font = 'bold 1em proxima-nova'
+    ctx.font = 'bold 1em ' + fontFamily
     ctx.fillStyle = contrastColor || 'white'
     ctx.textAlign = 'center'
     ctx.fillText(buttonText || 'Spin', centerX, centerY + 3)
@@ -193,7 +194,7 @@ const WheelComponent = ({
     ctx.textAlign = 'center'
     ctx.textBaseline = 'middle'
     ctx.fillStyle = primaryColor || 'black'
-    ctx.font = 'bold 1.5em proxima-nova'
+    ctx.font = 'bold 1.5em ' + fontFamily
     currentSegment = segments[i]
     isStarted && ctx.fillText(currentSegment, centerX + 10, centerY + size + 50)
   }


### PR DESCRIPTION
Changes Included:
- Added option `fontFamily` to override default font used in canvasContext styles
- Updated property table in documentation
- Updated example in README to show how to set the component option 

Currently the component uses the font-family name `'proxima-nova'` when setting the text styles to be written to the canvas. Unfortunately, this font is not available for most people, so most systems will fallback to a browser's default serif font, like Times or Times New Roman, which is a less attractive option.